### PR TITLE
Add support for PHP8 and update tests to work with newer phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
+  - 8.0
 cache:
   directories:
     - $HOME/.composer/cache/files

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 php:
   - 7.2
   - 7.3
-  - 7.4
   - 8.0
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*"
     },
     "autoload": {
@@ -24,6 +24,6 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.1",
-        "phpunit/phpunit": "^7"
+        "phpunit/phpunit": "^8"
     }
 }

--- a/src/Events/RiseSetTransit/RiseSetTransit.php
+++ b/src/Events/RiseSetTransit/RiseSetTransit.php
@@ -65,7 +65,7 @@ class RiseSetTransit
         return $toi;
     }
 
-    public function getSet(): TimeOfInterest
+    public function getSet(): ?TimeOfInterest
     {
         $jd0 = $this->toi->getJulianDay0();
         $m = $this->getApproximatedM(self::EVENT_TYPE_SET);
@@ -92,6 +92,8 @@ class RiseSetTransit
         $d2 = $coord2->getDeclination();
         $ra3 = $coord3->getRightAscension();
         $d3 = $coord3->getDeclination();
+
+        list($ra1, $ra2, $ra3) = $this->fix360Crossing([$ra1, $ra2, $ra3]);
 
         $m = $this->getApproximatedM($eventType);
 
@@ -215,4 +217,37 @@ class RiseSetTransit
 
         return $m;
     }
+
+    private function fix360Crossing(array $raArray): array
+    {
+        $result = [];
+
+        $add = 0;
+        $previousValue = 0;
+
+        for ($i = 0; $i < count($raArray); $i++) {
+            $currentValue = $raArray[$i];
+
+            if ($i > 0 && $previousValue - $currentValue > 270) {
+                $add += 360;
+            }
+
+            if ($i > 0 && $currentValue - $previousValue > 270) {
+                $add -= 360;
+            }
+
+            $result[] = $currentValue + $add;
+            $previousValue = $currentValue;
+        }
+
+        if ($add < 0) {
+            return array_map(function ($e) {
+                return $e + 360;
+            }, $result);
+        }
+
+        return $result;
+    }
+
+
 }

--- a/tests/Coordinates/GeocentricEclipticalRectangularCoordinatesTest.php
+++ b/tests/Coordinates/GeocentricEclipticalRectangularCoordinatesTest.php
@@ -13,7 +13,7 @@ class GeocentricEclipticalRectangularCoordinatesTest extends TestCase
     /** @var GeocentricEclipticalRectangularCoordinates */
     private $geoEclRecCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $x = 0.6217509;
         $y = -0.6648001;

--- a/tests/Coordinates/GeocentricEclipticalSphericalCoordinatesTest.php
+++ b/tests/Coordinates/GeocentricEclipticalSphericalCoordinatesTest.php
@@ -13,7 +13,7 @@ class GeocentricEclipticalSphericalCoordinatesTest extends TestCase
     /** @var GeocentricEclipticalSphericalCoordinates */
     private $geoEclSphCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $longitude = 313.083545;
         $latitude = -2.084642;

--- a/tests/Coordinates/GeocentricEquatorialRectangularCoordinatesTest.php
+++ b/tests/Coordinates/GeocentricEquatorialRectangularCoordinatesTest.php
@@ -13,7 +13,7 @@ class GeocentricEquatorialRectangularCoordinatesTest extends TestCase
     /** @var GeocentricEquatorialRectangularCoordinates */
     private $geoEquRecCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $x = 0.6217509;
         $y = -0.5967581;

--- a/tests/Coordinates/GeocentricEquatorialSphericalCoordinatesTest.php
+++ b/tests/Coordinates/GeocentricEquatorialSphericalCoordinatesTest.php
@@ -13,7 +13,7 @@ class GeocentricEquatorialSphericalCoordinatesTest extends TestCase
     /** @var GeocentricEquatorialSphericalCoordinates */
     private $geoEquSphCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $rightAscension = 316.175027;
         $declination = -18.887572;

--- a/tests/Coordinates/HeliocentricEclipticalRectangularCoordinatesTest.php
+++ b/tests/Coordinates/HeliocentricEclipticalRectangularCoordinatesTest.php
@@ -13,7 +13,7 @@ class HeliocentricEclipticalRectangularCoordinatesTest extends TestCase
     /** @var HeliocentricEclipticalRectangularCoordinates */
     private $helEclRecCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $x = 0.6499472;
         $y = 0.3186199;

--- a/tests/Coordinates/HeliocentricEclipticalSphericalCoordinatesTest.php
+++ b/tests/Coordinates/HeliocentricEclipticalSphericalCoordinatesTest.php
@@ -13,7 +13,7 @@ class HeliocentricEclipticalSphericalCoordinatesTest extends TestCase
     /** @var HeliocentricEclipticalSphericalCoordinates */
     private $helEclSphCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $longitude = 26.115216;
         $latitude = -2.620557;

--- a/tests/Coordinates/HeliocentricEquatorialRectangularCoordinatesTest.php
+++ b/tests/Coordinates/HeliocentricEquatorialRectangularCoordinatesTest.php
@@ -13,7 +13,7 @@ class HeliocentricEquatorialRectangularCoordinatesTest extends TestCase
     /** @var HeliocentricEquatorialRectangularCoordinates */
     private $helEquRecCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $x = 0.6499472;
         $y = 0.3055048;

--- a/tests/Coordinates/HeliocentricEquatorialSphericalCoordinatesTest.php
+++ b/tests/Coordinates/HeliocentricEquatorialSphericalCoordinatesTest.php
@@ -13,7 +13,7 @@ class HeliocentricEquatorialSphericalCoordinatesTest extends TestCase
     /** @var HeliocentricEquatorialSphericalCoordinates */
     private $helEquSphCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $rightAscension = 25.175663;
         $declination = 7.641117;

--- a/tests/Events/RiseSetTransit/RiseSetTransitTest.php
+++ b/tests/Events/RiseSetTransit/RiseSetTransitTest.php
@@ -14,6 +14,8 @@ use Andrmoel\AstronomyBundle\Events\RiseSetTransit\RiseSetTransit;
 use Andrmoel\AstronomyBundle\Location;
 use Andrmoel\AstronomyBundle\Tests\Traits\InvokeTrait;
 use Andrmoel\AstronomyBundle\TimeOfInterest;
+use DateTime;
+use DateTimeZone;
 use PHPUnit\Framework\TestCase;
 
 class RiseSetTransitTest extends TestCase
@@ -22,12 +24,43 @@ class RiseSetTransitTest extends TestCase
 
     /**
      * @test
+     */
+    public function fix360CrossingTest()
+    {
+        date_default_timezone_set('Pacific/Auckland');
+        $data = [
+            ["day" => 19, "sunrise" => "2022-03-19T18:23:37.000+13:00", "sunset" => "2022-03-19T06:34:46.000+13:00"],
+            ["day" => 20, "sunrise" => "2022-03-20T18:24:30.000+13:00", "sunset" => "2022-03-20T06:33:17.000+13:00"],
+            ["day" => 21, "sunrise" => "2022-03-21T18:25:23.000+13:00", "sunset" => "2022-03-21T06:31:48.000+13:00"],
+            ["day" => 22, "sunrise" => "2022-03-22T18:26:16.000+13:00", "sunset" => "2022-03-22T06:30:19.000+13:00"]
+        ];
+
+        foreach ($data as $datum) {
+            $location = Location::create(-36.86297, 174.71185);
+            $datetime = new DateTime("2022-03-" . $datum['day'] . "T00:00:00.000+00:00", new DateTimeZone("UTC"));
+
+            $date = (clone($datetime))->setTime(...[23, 59, 59])->setTimezone(new DateTimeZone('UTC'));
+            $toi = TimeOfInterest::createFromDateTime($date);
+
+            $sun = Sun::create($toi);
+
+            $rise = $sun->getSunrise($location);
+            $set = $sun->getSunset($location);
+
+            $this->assertEquals($datum['sunrise'],$rise->getDateTime()->format(DATE_RFC3339_EXTENDED));
+            $this->assertEquals($datum['sunset'],$set->getDateTime()->format(DATE_RFC3339_EXTENDED));
+
+        }
+    }
+
+    /**
+     * @test
      * Meeus 15.a
      */
     public function getRiseTest()
     {
         $astronomicalObjects = [
-            Sun::class => ['2019-05-31', '2019-05-31 09:10:49'],
+            Sun::class   => ['2019-05-31', '2019-05-31 09:10:49'],
             Venus::class => ['1988-03-20', '1988-03-20 12:25:25'],
         ];
 
@@ -47,33 +80,10 @@ class RiseSetTransitTest extends TestCase
      * @test
      * Meeus 15.a
      */
-    public function getTransitTest()
-    {
-        $astronomicalObjects = [
-            Sun::class => ['2019-05-31', '2019-05-31 16:42:01'],
-            Venus::class => ['1988-03-20', '1988-03-20 19:40:30'],
-        ];
-
-        $location = Location::create(42.3333, -71.0833);
-
-        foreach ($astronomicalObjects as $astronomicalObject => $expectedToi) {
-            $toi = TimeOfInterest::createFromString($expectedToi[0]);
-
-            $riseSetTransit = new RiseSetTransit($astronomicalObject, $location, $toi);
-            $toiTransit = $riseSetTransit->getTransit();
-
-            $this->assertEquals($expectedToi[1], $toiTransit);
-        }
-    }
-
-    /**
-     * @test
-     * Meeus 15.a
-     */
     public function getSetTest()
     {
         $astronomicalObjects = [
-            Sun::class => ['2019-05-31', '2019-05-31 00:12:49'],
+            Sun::class   => ['2019-05-31', '2019-05-31 00:12:49'],
             Venus::class => ['1988-03-20', '1988-03-20 02:54:39'],
         ];
 
@@ -95,13 +105,13 @@ class RiseSetTransitTest extends TestCase
     public function getStandardAltitudeTest()
     {
         $astronomicalObjects = [
-            Sun::class => -0.8333,
+            Sun::class     => -0.8333,
             Mercury::class => -0.5667,
-            Venus::class => -0.5667,
-            Mars::class => -0.5667,
+            Venus::class   => -0.5667,
+            Mars::class    => -0.5667,
             Jupiter::class => -0.5667,
-            Saturn::class => -0.5667,
-            Uranus::class => -0.5667,
+            Saturn::class  => -0.5667,
+            Uranus::class  => -0.5667,
             Neptune::class => -0.5667,
         ];
 
@@ -115,4 +125,28 @@ class RiseSetTransitTest extends TestCase
             $this->assertEquals($expectedStdAlt, $stdAlt);
         }
     }
+
+    /**
+     * @test
+     * Meeus 15.a
+     */
+    public function getTransitTest()
+    {
+        $astronomicalObjects = [
+            Sun::class   => ['2019-05-31', '2019-05-31 16:42:01'],
+            Venus::class => ['1988-03-20', '1988-03-20 19:40:30'],
+        ];
+
+        $location = Location::create(42.3333, -71.0833);
+
+        foreach ($astronomicalObjects as $astronomicalObject => $expectedToi) {
+            $toi = TimeOfInterest::createFromString($expectedToi[0]);
+
+            $riseSetTransit = new RiseSetTransit($astronomicalObject, $location, $toi);
+            $toiTransit = $riseSetTransit->getTransit();
+
+            $this->assertEquals($expectedToi[1], $toiTransit);
+        }
+    }
+
 }


### PR DESCRIPTION
I allowed for PHP 8 to be used and upgrade PHPUnit to a version compatible with it. I had to match the return type of some of the PHPUnit functions.