### PR TITLE
Add Support for PHP 8.0/8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 composer.lock
 /phpunit.xml
 phpunit.phar
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*"
     },
     "autoload": {
@@ -24,6 +24,6 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.1",
-        "phpunit/phpunit": "^7"
+        "phpunit/phpunit": "^8"
     }
 }

--- a/src/Calculations/TimeCalc.php
+++ b/src/Calculations/TimeCalc.php
@@ -311,7 +311,7 @@ class TimeCalc
         $second = 60 * ($minuteFloat - $minute);
         $second = round($second);
 
-        return new Time($year, $month, $day, $hour, $minute, $second);
+        return new Time($year, $month, (int)$day, (int)$hour, (int)$minute, (int)$second);
     }
 
 
@@ -330,7 +330,7 @@ class TimeCalc
     public static function getDayOfWeek(float $JD): int
     {
         // Meeus 7.e
-        $DOW = ($JD + 1.5) % 7;
+        $DOW = (int)($JD + 1.5) % 7;
 
         return $DOW;
     }

--- a/tests/Coordinates/GeocentricEclipticalRectangularCoordinatesTest.php
+++ b/tests/Coordinates/GeocentricEclipticalRectangularCoordinatesTest.php
@@ -13,7 +13,7 @@ class GeocentricEclipticalRectangularCoordinatesTest extends TestCase
     /** @var GeocentricEclipticalRectangularCoordinates */
     private $geoEclRecCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $x = 0.6217509;
         $y = -0.6648001;

--- a/tests/Coordinates/GeocentricEclipticalSphericalCoordinatesTest.php
+++ b/tests/Coordinates/GeocentricEclipticalSphericalCoordinatesTest.php
@@ -13,7 +13,7 @@ class GeocentricEclipticalSphericalCoordinatesTest extends TestCase
     /** @var GeocentricEclipticalSphericalCoordinates */
     private $geoEclSphCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $longitude = 313.083545;
         $latitude = -2.084642;

--- a/tests/Coordinates/GeocentricEquatorialRectangularCoordinatesTest.php
+++ b/tests/Coordinates/GeocentricEquatorialRectangularCoordinatesTest.php
@@ -13,7 +13,7 @@ class GeocentricEquatorialRectangularCoordinatesTest extends TestCase
     /** @var GeocentricEquatorialRectangularCoordinates */
     private $geoEquRecCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $x = 0.6217509;
         $y = -0.5967581;

--- a/tests/Coordinates/GeocentricEquatorialSphericalCoordinatesTest.php
+++ b/tests/Coordinates/GeocentricEquatorialSphericalCoordinatesTest.php
@@ -13,7 +13,7 @@ class GeocentricEquatorialSphericalCoordinatesTest extends TestCase
     /** @var GeocentricEquatorialSphericalCoordinates */
     private $geoEquSphCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $rightAscension = 316.175027;
         $declination = -18.887572;

--- a/tests/Coordinates/HeliocentricEclipticalRectangularCoordinatesTest.php
+++ b/tests/Coordinates/HeliocentricEclipticalRectangularCoordinatesTest.php
@@ -13,7 +13,7 @@ class HeliocentricEclipticalRectangularCoordinatesTest extends TestCase
     /** @var HeliocentricEclipticalRectangularCoordinates */
     private $helEclRecCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $x = 0.6499472;
         $y = 0.3186199;

--- a/tests/Coordinates/HeliocentricEclipticalSphericalCoordinatesTest.php
+++ b/tests/Coordinates/HeliocentricEclipticalSphericalCoordinatesTest.php
@@ -13,7 +13,7 @@ class HeliocentricEclipticalSphericalCoordinatesTest extends TestCase
     /** @var HeliocentricEclipticalSphericalCoordinates */
     private $helEclSphCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $longitude = 26.115216;
         $latitude = -2.620557;

--- a/tests/Coordinates/HeliocentricEquatorialRectangularCoordinatesTest.php
+++ b/tests/Coordinates/HeliocentricEquatorialRectangularCoordinatesTest.php
@@ -13,7 +13,7 @@ class HeliocentricEquatorialRectangularCoordinatesTest extends TestCase
     /** @var HeliocentricEquatorialRectangularCoordinates */
     private $helEquRecCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $x = 0.6499472;
         $y = 0.3055048;

--- a/tests/Coordinates/HeliocentricEquatorialSphericalCoordinatesTest.php
+++ b/tests/Coordinates/HeliocentricEquatorialSphericalCoordinatesTest.php
@@ -13,7 +13,7 @@ class HeliocentricEquatorialSphericalCoordinatesTest extends TestCase
     /** @var HeliocentricEquatorialSphericalCoordinates */
     private $helEquSphCoord;
 
-    public function setUp()
+    public function setUp(): void
     {
         $rightAscension = 25.175663;
         $declination = 7.641117;


### PR DESCRIPTION
add support for PHP 8.0 and PHP 8.1

- update version requirements in `composer.json` for PHP and PHPUnit
- update method signatures in test cases (`setUp(): void`)
- fix implicit type conversions with explicit type casting